### PR TITLE
タスク統計APIエンドポイントを追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,6 +150,8 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
+    nokogiri (1.18.10-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.18.10-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.10-x86_64-linux-gnu)
@@ -233,6 +235,8 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2025.3)
+      tzinfo (>= 1.0.0)
     web-console (4.2.0)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -252,6 +256,7 @@ GEM
     zeitwerk (2.7.3)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-darwin-21
   x86_64-darwin-23
   x86_64-linux

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -26,6 +26,15 @@ class TasksController < ApplicationController
     tasks_all
   end
 
+  def report
+    stats = Task.statistics
+    @total_count = stats[:total_count]
+    @count_by_status = stats[:count_by_status]
+    @completion_rate = stats[:completion_rate]
+
+    render :report
+  end
+
   private
 
   def task_params

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,3 +1,29 @@
 class Task < ApplicationRecord
   belongs_to :genre
+
+  enum status: {
+    not_started: 0,
+    in_progress: 1,
+    completed: 2
+  }
+
+  def self.statistics
+    counts = group(:status).count
+    total = counts.values.sum
+
+    {
+      total_count: total,
+      count_by_status: {
+        not_started: counts[statuses[:not_started]] || 0,
+        in_progress: counts[statuses[:in_progress]] || 0,
+        completed: counts[statuses[:completed]] || 0
+      },
+      completion_rate: calculate_completion_rate(total, counts[statuses[:completed]] || 0)
+    }
+  end
+
+  def self.calculate_completion_rate(total, completed)
+    return 0.0 if total.zero?
+    ((completed.to_f / total) * 100).round(1)
+  end
 end

--- a/app/views/tasks/report.json.jbuilder
+++ b/app/views/tasks/report.json.jbuilder
@@ -1,0 +1,7 @@
+json.totalCount @total_count
+json.countByStatus do
+  json.notStarted @count_by_status[:not_started]
+  json.inProgress @count_by_status[:in_progress]
+  json.completed @count_by_status[:completed]
+end
+json.completionRate @completion_rate

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,8 @@
 Rails.application.routes.draw do
   resources :tasks , defaults: {format: 'json'} do
+    collection do
+      get :report
+    end
     member do
       post :status, to: "tasks#update_status", defaults: {format: 'json'}
     end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,7 +1,52 @@
 require "test_helper"
 
 class TasksControllerTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
+  setup do
+    @genre = Genre.create!(name: "Test Genre")
+  end
+
+  test "should get report with correct statistics" do
+    # テストデータ作成
+    Task.create!(name: "Task 1", status: :not_started, genre: @genre)
+    Task.create!(name: "Task 2", status: :in_progress, genre: @genre)
+    Task.create!(name: "Task 3", status: :completed, genre: @genre)
+    Task.create!(name: "Task 4", status: :completed, genre: @genre)
+
+    get report_tasks_url, as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+
+    assert_equal 4, json["totalCount"]
+    assert_equal 1, json["countByStatus"]["notStarted"]
+    assert_equal 1, json["countByStatus"]["inProgress"]
+    assert_equal 2, json["countByStatus"]["completed"]
+    assert_equal 50.0, json["completionRate"]
+  end
+
+  test "should return 0 completion rate when no tasks exist" do
+    Task.destroy_all
+
+    get report_tasks_url, as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+
+    assert_equal 0, json["totalCount"]
+    assert_equal 0.0, json["completionRate"]
+  end
+
+  test "should handle 100 percent completion rate" do
+    Task.create!(name: "Task 1", status: :completed, genre: @genre)
+    Task.create!(name: "Task 2", status: :completed, genre: @genre)
+
+    get report_tasks_url, as: :json
+
+    assert_response :success
+    json = JSON.parse(response.body)
+
+    assert_equal 2, json["totalCount"]
+    assert_equal 2, json["countByStatus"]["completed"]
+    assert_equal 100.0, json["completionRate"]
+  end
 end


### PR DESCRIPTION
Issue #2に対応し、/tasks/report エンドポイントを実装。
タスクの総数、ステータス別タスク数、完了率を返すJSON APIを提供。

実装内容:
- Taskモデルにステータスenum定義を追加 (not_started, in_progress, completed)
- Task.statisticsメソッドを実装し、統計ロジックをモデルに配置
- クエリを最適化し、1クエリで全統計データを取得
- TasksController#reportアクションを追加
- app/views/tasks/report.json.jbuilderビューを作成（camelCase形式）
- テストケースを追加（正常系、エッジケース含む）

Rails Wayに準拠:
- Fat Model, Skinny Controller原則に従い、ビジネスロジックをモデルに配置
- パフォーマンス最適化（4クエリ→1クエリ）